### PR TITLE
Create table "guild" if missing

### DIFF
--- a/serenity-command-handler/src/db.rs
+++ b/serenity-command-handler/src/db.rs
@@ -38,6 +38,9 @@ impl Db {
     }
 
     pub fn add_guild_field(&mut self, name: &str, def: &str) -> anyhow::Result<()> {
+        self.conn
+            .execute(&"CREATE TABLE IF NOT EXISTS guild(id INTEGER PRIMARY KEY)", [])
+            .map_err(anyhow::Error::from)?;
         let count: usize = self.conn.query_row(
             "SELECT COUNT(*) FROM pragma_table_info('guild') WHERE name = ?1",
             [name],


### PR DESCRIPTION
Starting humble-ledger with an empty database leads to an SQL error : `no such table: guild`

The culprit seems to be https://github.com/etwyniel/discord_framework/blob/0d5862ba31ddfc1c41c8a9715d7fb8d3fbccf489/serenity-command-handler/src/modules/album_lookup.rs#L136, the setup for `AlbumLookup` tries to add a field to the `guild` table which is never created.

* This PR changes `add_guild_field` to also create the table in case it is missing. I'm not sure this is the optimal place to do this, but it seemed sensible enough, since this is a setup function. It also seems to pacify humble-ledger. 
* This implicitly also fixes other modules that try to add fields without checking that the table exists. 

It also adds a surrogate primary key since zero-column tables aren't allowed in sqlite and a primary key is generally a good idea
